### PR TITLE
Fix crash on in-progress game pages

### DIFF
--- a/src/app/game/[id]/page.tsx
+++ b/src/app/game/[id]/page.tsx
@@ -170,7 +170,7 @@ export default async function GamePage({
 
   const goals: any[] = summary.goals ?? [];
   const penalties: any[] = summary.penalties ?? [];
-  const threeStars: any[] = summary.mvps ?? summary.three_stars ?? [];
+  const threeStars: any[] = (summary.mvps ?? summary.three_stars ?? []).filter(Boolean);
 
   // Group goals by period
   const goalsByPeriod: Record<string, any[]> = {};


### PR DESCRIPTION
## Summary
- Filter null entries from `mvps` array before rendering Three Stars section
- The HockeyTech API returns `[null, null, null]` for MVPs during live games since three stars haven't been selected yet
- One-line fix: `.filter(Boolean)` on the mvps array

## Test plan
- [ ] Navigate to an in-progress game — page renders without crashing
- [ ] Navigate to a completed game — Three Stars still display correctly
- [ ] `npm run build` compiles cleanly

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)