### PR TITLE
Simplify codebase: parallelize fetches, extract utils, clean up

### DIFF
--- a/src/app/game/[id]/page.tsx
+++ b/src/app/game/[id]/page.tsx
@@ -1,13 +1,11 @@
-import { getGameSummary, getPlayByPlay, extractSiteKit } from "@/lib/api";
+import { getGameSummary, getPlayByPlay } from "@/lib/api";
 import { getTeamMeta } from "@/lib/teams";
+import { val, playerName } from "@/lib/utils";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-
 import type { Metadata } from "next";
 
 export const revalidate = 60;
-
-import { val } from "@/lib/utils";
 
 export async function generateMetadata({
   params,
@@ -25,16 +23,12 @@ export async function generateMetadata({
 
 function GoalRow({ goal }: { goal: any }) {
   const team = getTeamMeta(goal.team_id ?? goal.team ?? 0);
-  const scorer = goal.goal_scorer;
-  const scorerName = typeof scorer === "object"
-    ? `${scorer?.first_name ?? ""} ${scorer?.last_name ?? ""}`.trim()
-    : scorer ?? "Goal";
-  const assist1 = goal.assist1_player;
-  const assist2 = goal.assist2_player;
-  const assists = [assist1, assist2]
+  const scorerName = typeof goal.goal_scorer === "object"
+    ? playerName(goal.goal_scorer)
+    : goal.goal_scorer ?? "Goal";
+  const assists = [goal.assist1_player, goal.assist2_player]
     .filter((a) => a?.player_id)
-    .map((a) => `${a.first_name ?? ""} ${a.last_name ?? ""}`.trim())
-    .filter(Boolean);
+    .map((a) => playerName(a));
 
   return (
     <div className="flex items-start gap-3 py-2.5 border-b border-rink-800/30 last:border-0">
@@ -82,9 +76,8 @@ function GoalRow({ goal }: { goal: any }) {
 
 function PenaltyRow({ pen }: { pen: any }) {
   const team = getTeamMeta(pen.team_id ?? pen.team ?? 0);
-  const penPlayer = pen.player_penalized_info;
-  const playerName = penPlayer
-    ? `${penPlayer.first_name ?? ""} ${penPlayer.last_name ?? ""}`.trim()
+  const penPlayerName = pen.player_penalized_info
+    ? playerName(pen.player_penalized_info)
     : pen.player_penalized_name ?? "Player";
 
   return (
@@ -96,7 +89,7 @@ function PenaltyRow({ pen }: { pen: any }) {
         {team.abbr}
       </div>
       <div className="flex-1">
-        <span className="text-sm text-gray-300">{playerName}</span>
+        <span className="text-sm text-gray-300">{penPlayerName}</span>
         <span className="text-xs text-gray-500 ml-2">
           {pen.minutes_formatted ?? `${pen.minutes ?? 2} min`} —{" "}
           {pen.lang_penalty_description ?? pen.offence ?? "Penalty"}
@@ -118,25 +111,16 @@ export default async function GamePage({
   const gameId = parseInt(id);
   if (isNaN(gameId) || gameId < 1) notFound();
 
-  let summary: any = null;
-  let pbp: any[] = [];
+  const [summaryResult, pbpResult] = await Promise.allSettled([
+    getGameSummary(gameId),
+    getPlayByPlay(gameId),
+  ]);
 
-  try {
-    const data = await getGameSummary(gameId);
-    summary = extractSiteKit(data, "Gamesummary");
-  } catch (error) {
-    console.error(`[GamePage] Failed to fetch game summary for game ${gameId}:`, error);
-    summary = null;
-  }
+  const summary = summaryResult.status === "fulfilled" ? summaryResult.value : null;
+  const pbp = pbpResult.status === "fulfilled" ? pbpResult.value : [];
 
-  try {
-    const data = await getPlayByPlay(gameId);
-    const raw = extractSiteKit(data, "Pxpverbose");
-    pbp = Array.isArray(raw) ? raw : [];
-  } catch (error) {
-    console.error(`[GamePage] Failed to fetch play-by-play for game ${gameId}:`, error);
-    pbp = [];
-  }
+  if (summaryResult.status === "rejected") console.error(`[GamePage] Failed to fetch summary for game ${gameId}:`, summaryResult.reason);
+  if (pbpResult.status === "rejected") console.error(`[GamePage] Failed to fetch PBP for game ${gameId}:`, pbpResult.reason);
 
   if (!summary) {
     return (
@@ -366,8 +350,7 @@ export default async function GamePage({
                       </div>
                       <div>
                         <p className="text-sm font-medium text-white">
-                          {star.name ??
-                            `${star.first_name ?? ""} ${star.last_name ?? ""}`.trim()}
+                          {playerName(star)}
                         </p>
                         <p className="text-[10px] text-gray-500">
                           #{star.jersey_number ?? ""} &middot; {starTeam.city}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,13 +3,6 @@
 @tailwind utilities;
 
 @layer base {
-  :root {
-    --rink-950: #04080f;
-    --rink-900: #0a1628;
-    --rink-800: #132842;
-    --ice: #c8e6f5;
-  }
-
   html {
     color-scheme: dark;
   }
@@ -46,10 +39,6 @@
     white-space: nowrap;
   }
 
-  .stat-table thead th.sortable {
-    @apply cursor-pointer hover:text-ice transition-colors select-none;
-  }
-
   .stat-table tbody td {
     @apply px-3 py-2.5 border-b border-rink-800/30 whitespace-nowrap;
   }
@@ -83,10 +72,6 @@
       px-3 py-1.5 rounded-md hover:bg-rink-800/50;
   }
 
-  .nav-link-active {
-    @apply text-white bg-rink-800/70;
-  }
-
   .page-header {
     @apply mb-8;
   }
@@ -118,8 +103,3 @@
   @apply bg-rink-600;
 }
 
-/* Number columns right-aligned in tables */
-.stat-table th.num,
-.stat-table td.num {
-  @apply text-right;
-}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -45,7 +45,6 @@ export default function RootLayout({
       className={`${display.variable} ${body.variable} ${mono.variable}`}
     >
       <body className="font-body min-h-screen flex flex-col">
-        {/* Top bar */}
         <header className="sticky top-0 z-50 border-b border-rink-700/40 bg-rink-950/90 backdrop-blur-xl">
           <div className="mx-auto max-w-7xl px-4 h-14 flex items-center justify-between">
             <Link href="/" className="flex items-center gap-2.5 group">
@@ -78,12 +77,10 @@ export default function RootLayout({
           </div>
         </header>
 
-        {/* Main */}
         <main className="flex-1 mx-auto max-w-7xl w-full px-4 py-8">
           {children}
         </main>
 
-        {/* Footer */}
         <footer className="border-t border-rink-800/40 py-6 mt-auto">
           <div className="mx-auto max-w-7xl px-4 flex items-center justify-between text-xs text-gray-500">
             <span>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
-import { getScorebar, getStandings, getTopScorers, extractSiteKit } from "@/lib/api";
+import { getScorebar, getStandings, getTopScorers } from "@/lib/api";
 import { getTeamMeta } from "@/lib/teams";
+import { playerName, isGameLive, isGameFinal } from "@/lib/utils";
 import { ErrorBanner } from "@/components/error-banner";
 import Link from "next/link";
 
@@ -41,20 +42,19 @@ function ScoreCard({ game }: { game: any }) {
   const gameId = game.ID ?? game.game_id;
   const gameDate = game.GameDate ?? game.date_with_day ?? "";
   const gameTime = game.ScheduledFormattedTime ?? game.schedule_time ?? "";
-  // GameStatus codes: 1=Not Started, 2=In Progress, 3=Intermission, 4=Final
-  const isLive = statusCode === "2" || statusCode === "3" || statusStr.toLowerCase().includes("progress");
-  const isFinal = statusCode === "4" || statusStr.toLowerCase().includes("final");
+  const live = isGameLive(statusCode || statusStr);
+  const final_ = isGameFinal(statusCode || statusStr);
 
   return (
     <Link
       href={`/game/${gameId}`}
       className={`glass-card block transition-all hover:scale-[1.02] hover:border-rink-600/50 ${
-        isLive ? "ring-1 ring-live/30" : ""
+        live ? "ring-1 ring-live/30" : ""
       }`}
     >
       <div className="p-4">
         <div className="flex items-center justify-between mb-3">
-          <GameStatus status={statusStr || (isFinal ? "Final" : isLive ? "In Progress" : "Scheduled")} />
+          <GameStatus status={statusStr || (final_ ? "Final" : live ? "In Progress" : "Scheduled")} />
           {gameDate && (
             <span className="text-[10px] text-gray-500 uppercase tracking-wide">
               {gameDate}
@@ -62,7 +62,7 @@ function ScoreCard({ game }: { game: any }) {
           )}
         </div>
 
-        {/* Away team */}
+
         <div className="flex items-center justify-between py-1.5">
           <div className="flex items-center gap-2.5">
             <div
@@ -75,14 +75,14 @@ function ScoreCard({ game }: { game: any }) {
               {game.VisitorLongName ?? `${awayTeam.city} ${awayTeam.name}`}
             </span>
           </div>
-          {(isLive || isFinal) && (
+          {(live || final_) && (
             <span className="font-mono text-xl font-bold text-white tabular-nums">
               {awayScore}
             </span>
           )}
         </div>
 
-        {/* Home team */}
+
         <div className="flex items-center justify-between py-1.5">
           <div className="flex items-center gap-2.5">
             <div
@@ -95,14 +95,14 @@ function ScoreCard({ game }: { game: any }) {
               {game.HomeLongName ?? `${homeTeam.city} ${homeTeam.name}`}
             </span>
           </div>
-          {(isLive || isFinal) && (
+          {(live || final_) && (
             <span className="font-mono text-xl font-bold text-white tabular-nums">
               {homeScore}
             </span>
           )}
         </div>
 
-        {isLive && (
+        {live && (
           <div className="mt-2 text-center">
             <span className="text-xs font-mono text-ice-dim">
               {game.PeriodNameLong ?? game.PeriodNameShort ?? ""}{" "}
@@ -111,7 +111,7 @@ function ScoreCard({ game }: { game: any }) {
           </div>
         )}
 
-        {!isLive && !isFinal && gameTime && (
+        {!live && !final_ && gameTime && (
           <div className="mt-2 text-center">
             <span className="text-sm font-mono text-ice-dim">{gameTime}</span>
           </div>
@@ -212,9 +212,7 @@ function TopScorersPreview({ scorers }: { scorers: any[] }) {
                     />
                     <div>
                       <span className="font-medium text-sm">
-                        {p.player_name ??
-                          p.name ??
-                          `${p.first_name ?? ""} ${p.last_name ?? ""}`}
+                        {playerName(p)}
                       </span>
                       <span className="ml-1.5 text-[10px] text-gray-500">
                         {team.abbr}
@@ -237,39 +235,20 @@ function TopScorersPreview({ scorers }: { scorers: any[] }) {
 }
 
 export default async function HomePage() {
-  let scorebar: any[] = [];
-  let standings: any[] = [];
-  let topScorers: any[] = [];
-  let scorebarError = false;
+  const [scorebarResult, standingsResult, scorersResult] = await Promise.allSettled([
+    getScorebar(3, 3),
+    getStandings(),
+    getTopScorers(),
+  ]);
 
-  try {
-    const scoreData = await getScorebar(3, 3);
-    const raw = extractSiteKit(scoreData, "Scorebar");
-    scorebar = Array.isArray(raw) ? raw : [];
-  } catch (error) {
-    console.error("[HomePage] Failed to fetch scorebar:", error);
-    scorebarError = true;
-  }
+  const scorebar = scorebarResult.status === "fulfilled" ? scorebarResult.value : [];
+  const standings = standingsResult.status === "fulfilled" ? standingsResult.value : [];
+  const topScorers = scorersResult.status === "fulfilled" ? scorersResult.value : [];
+  const scorebarError = scorebarResult.status === "rejected";
 
-  try {
-    const standData = await getStandings();
-    const raw = extractSiteKit(standData, "Statviewtype");
-    standings = Array.isArray(raw)
-      ? raw.filter((r: any) => r.team_id)
-      : [];
-  } catch (error) {
-    console.error("[HomePage] Failed to fetch standings:", error);
-  }
-
-  try {
-    const scorerData = await getTopScorers();
-    const raw = extractSiteKit(scorerData, "Statviewtype");
-    topScorers = Array.isArray(raw)
-      ? raw.filter((r: any) => r.player_name || r.name || r.first_name)
-      : [];
-  } catch (error) {
-    console.error("[HomePage] Failed to fetch top scorers:", error);
-  }
+  if (scorebarResult.status === "rejected") console.error("[HomePage] Failed to fetch scorebar:", scorebarResult.reason);
+  if (standingsResult.status === "rejected") console.error("[HomePage] Failed to fetch standings:", standingsResult.reason);
+  if (scorersResult.status === "rejected") console.error("[HomePage] Failed to fetch top scorers:", scorersResult.reason);
 
   return (
     <div className="space-y-8 animate-fade-in">

--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -1,4 +1,4 @@
-import { getSeasonSchedule, extractSiteKit } from "@/lib/api";
+import { getSeasonSchedule, getTeamSchedule } from "@/lib/api";
 import { getTeamMeta, TEAM_LIST } from "@/lib/teams";
 import { formatDate } from "@/lib/utils";
 import { ErrorBanner } from "@/components/error-banner";
@@ -21,11 +21,13 @@ export default async function SchedulePage({
   const resolvedParams = await searchParams;
   let games: any[] = [];
 
+  const teamFilter = resolvedParams.team ? parseInt(resolvedParams.team) : null;
+
   let fetchError = false;
   try {
-    const data = await getSeasonSchedule();
-    const raw = extractSiteKit(data, "Schedule");
-    games = Array.isArray(raw) ? raw : [];
+    games = teamFilter
+      ? await getTeamSchedule(teamFilter)
+      : await getSeasonSchedule();
   } catch (error) {
     console.error("[SchedulePage] Failed to fetch schedule:", error);
     fetchError = true;
@@ -39,16 +41,6 @@ export default async function SchedulePage({
         </div>
         <ErrorBanner message="Unable to load schedule." />
       </div>
-    );
-  }
-
-  const teamFilter = resolvedParams.team ? parseInt(resolvedParams.team) : null;
-
-  if (teamFilter) {
-    games = games.filter(
-      (g: any) =>
-        parseInt(g.home_team) === teamFilter ||
-        parseInt(g.visiting_team) === teamFilter
     );
   }
 

--- a/src/app/standings/page.tsx
+++ b/src/app/standings/page.tsx
@@ -1,4 +1,4 @@
-import { getStandings, extractSiteKit } from "@/lib/api";
+import { getStandings } from "@/lib/api";
 import { getTeamMeta } from "@/lib/teams";
 import { ErrorBanner } from "@/components/error-banner";
 import Link from "next/link";
@@ -17,11 +17,7 @@ export default async function StandingsPage() {
   let fetchError = false;
 
   try {
-    const data = await getStandings();
-    const raw = extractSiteKit(data, "Statviewtype");
-    standings = Array.isArray(raw)
-      ? raw.filter((r: any) => r.team_id)
-      : [];
+    standings = await getStandings();
   } catch (error) {
     console.error("[StandingsPage] Failed to fetch standings:", error);
     fetchError = true;

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -1,6 +1,6 @@
-import { getSkaterStats, getGoalieStats, extractSiteKit } from "@/lib/api";
+import { getSkaterStats, getGoalieStats } from "@/lib/api";
 import { getTeamMeta, TEAM_LIST } from "@/lib/teams";
-import { val } from "@/lib/utils";
+import { val, playerName } from "@/lib/utils";
 import { ErrorBanner } from "@/components/error-banner";
 import Link from "next/link";
 
@@ -26,15 +26,9 @@ export default async function StatsPage({
 
   let fetchError = false;
   try {
-    if (view === "goalies") {
-      const data = await getGoalieStats();
-      const raw = extractSiteKit(data, "Players");
-      players = Array.isArray(raw) ? raw : [];
-    } else {
-      const data = await getSkaterStats();
-      const raw = extractSiteKit(data, "Players");
-      players = Array.isArray(raw) ? raw : [];
-    }
+    players = view === "goalies"
+      ? await getGoalieStats()
+      : await getSkaterStats();
   } catch (error) {
     console.error("[StatsPage] Failed to fetch player stats:", error);
     fetchError = true;
@@ -185,9 +179,7 @@ export default async function StatsPage({
             <tbody>
               {players.map((p: any, i: number) => {
                 const team = getTeamMeta(p.team_id ?? p.team_code ?? 0);
-                const name =
-                  p.name ??
-                  `${p.first_name ?? ""} ${p.last_name ?? ""}`.trim();
+                const name = playerName(p);
 
                 return (
                   <tr key={p.player_id ?? i}>

--- a/src/app/team/[id]/page.tsx
+++ b/src/app/team/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { getTeamRoster, getTeamSchedule, extractSiteKit } from "@/lib/api";
+import { getTeamRoster, getTeamSchedule } from "@/lib/api";
 import { getTeamMeta, TEAM_LIST } from "@/lib/teams";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -7,7 +7,7 @@ import type { Metadata } from "next";
 
 export const revalidate = 300;
 
-import { formatDate } from "@/lib/utils";
+import { formatDate, playerName } from "@/lib/utils";
 
 export async function generateMetadata({
   params,
@@ -37,26 +37,16 @@ export default async function TeamPage({
   let roster: any[] = [];
   let schedule: any[] = [];
 
-  try {
-    const data = await getTeamRoster(teamId);
-    const raw = extractSiteKit(data, "Roster");
-    roster = Array.isArray(raw) ? raw.filter((p: any) => typeof p === "object" && p !== null && !Array.isArray(p) && p.first_name) : [];
-    if (roster.length > 0 && roster[0]?.sections) {
-      roster = roster[0].sections.flatMap((s: any) => s.data ?? []);
-    }
-  } catch (error) {
-    console.error(`[TeamPage] Failed to fetch roster for team ${teamId}:`, error);
-    roster = [];
-  }
+  const [rosterResult, scheduleResult] = await Promise.allSettled([
+    getTeamRoster(teamId),
+    getTeamSchedule(teamId),
+  ]);
 
-  try {
-    const data = await getTeamSchedule(teamId);
-    const raw = extractSiteKit(data, "Schedule");
-    schedule = Array.isArray(raw) ? raw : [];
-  } catch (error) {
-    console.error(`[TeamPage] Failed to fetch schedule for team ${teamId}:`, error);
-    schedule = [];
-  }
+  roster = rosterResult.status === "fulfilled" ? rosterResult.value : [];
+  schedule = scheduleResult.status === "fulfilled" ? scheduleResult.value : [];
+
+  if (rosterResult.status === "rejected") console.error(`[TeamPage] Failed to fetch roster for team ${teamId}:`, rosterResult.reason);
+  if (scheduleResult.status === "rejected") console.error(`[TeamPage] Failed to fetch schedule for team ${teamId}:`, scheduleResult.reason);
 
   // Separate roster by position
   const forwards = roster.filter((p: any) =>
@@ -106,8 +96,7 @@ export default async function TeamPage({
                   </td>
                   <td>
                     <span className="font-medium text-sm text-white">
-                      {p.name ??
-                        `${p.first_name ?? ""} ${p.last_name ?? ""}`.trim()}
+                      {playerName(p)}
                     </span>
                   </td>
                   <td className="text-xs text-gray-400">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -106,37 +106,46 @@ async function firebaseFetch(path: string) {
 
 // --- Scorebar ---
 export async function getScorebar(daysBack = 1, daysAhead = 1) {
-  return htFetch(
+  const data = await htFetch(
     `feed=modulekit&view=scorebar&numberofdaysback=${daysBack}&numberofdaysahead=${daysAhead}`
   );
+  const raw = extractSiteKit(data, "Scorebar");
+  return Array.isArray(raw) ? raw : [];
 }
 
 // --- Schedule ---
 export async function getSeasonSchedule(seasonId = CURRENT_SEASON_ID) {
-  return htFetch(`feed=modulekit&view=schedule&season_id=${seasonId}`);
+  const data = await htFetch(`feed=modulekit&view=schedule&season_id=${seasonId}`);
+  const raw = extractSiteKit(data, "Schedule");
+  return Array.isArray(raw) ? raw : [];
 }
 
 export async function getTeamSchedule(
   teamId: number,
   seasonId = CURRENT_SEASON_ID
 ) {
-  return htFetch(
+  const data = await htFetch(
     `feed=statviewfeed&view=schedule&team=${teamId}&season=${seasonId}&month=-1`
   );
+  const raw = extractSiteKit(data, "Schedule");
+  return Array.isArray(raw) ? raw : [];
 }
 
 // --- Standings ---
 export async function getStandings(seasonId = CURRENT_SEASON_ID) {
-  return htFetch(
+  const data = await htFetch(
     `feed=modulekit&view=statviewtype&stat=conference&type=standings&season_id=${seasonId}`
   );
+  const raw = extractSiteKit(data, "Statviewtype");
+  return Array.isArray(raw) ? raw.filter((r: any) => r.team_id) : [];
 }
 
 // --- Game Detail ---
 export async function getGameSummary(gameId: number) {
-  return htFetch(
+  const data = await htFetch(
     `feed=gc&tab=gamesummary&game_id=${gameId}&site_id=0&lang=en`
   );
+  return extractSiteKit(data, "Gamesummary");
 }
 
 export async function getGameClock(gameId: number) {
@@ -144,7 +153,9 @@ export async function getGameClock(gameId: number) {
 }
 
 export async function getPlayByPlay(gameId: number) {
-  return htFetch(`feed=gc&tab=pxpverbose&game_id=${gameId}`);
+  const data = await htFetch(`feed=gc&tab=pxpverbose&game_id=${gameId}`);
+  const raw = extractSiteKit(data, "Pxpverbose");
+  return Array.isArray(raw) ? raw : [];
 }
 
 export async function getGamePreview(gameId: number) {
@@ -153,37 +164,51 @@ export async function getGamePreview(gameId: number) {
 
 // --- Player Stats ---
 export async function getSkaterStats(seasonId = CURRENT_SEASON_ID) {
-  return htFetch(
+  const data = await htFetch(
     `feed=statviewfeed&view=players&season=${seasonId}&team=all&position=skaters&rookies=0&statsType=standard&rosterstatus=undefined&site_id=0&league_id=1&lang=en&division=-1&conference=-1&limit=500&sort=points`
   );
+  const raw = extractSiteKit(data, "Players");
+  return Array.isArray(raw) ? raw : [];
 }
 
 export async function getGoalieStats(seasonId = CURRENT_SEASON_ID) {
-  return htFetch(
+  const data = await htFetch(
     `feed=statviewfeed&view=players&season=${seasonId}&team=all&position=goalies&rookies=0&statsType=standard&rosterstatus=undefined&site_id=0&first=0&limit=500&sort=gaa&league_id=1&lang=en&division=-1&conference=-1&qualified=all`
   );
+  const raw = extractSiteKit(data, "Players");
+  return Array.isArray(raw) ? raw : [];
 }
 
 export async function getTopScorers(seasonId = CURRENT_SEASON_ID) {
-  return htFetch(
+  const data = await htFetch(
     `feed=modulekit&view=statviewtype&type=topscorers&first=0&limit=100&season_id=${seasonId}`
   );
+  const raw = extractSiteKit(data, "Statviewtype");
+  return Array.isArray(raw) ? raw.filter((r: any) => r.player_name || r.name || r.first_name) : [];
 }
 
 // --- Teams ---
 export async function getTeams(seasonId = CURRENT_SEASON_ID) {
-  return htFetch(
+  const data = await htFetch(
     `feed=modulekit&view=teamsbyseason&season_id=${seasonId}`
   );
+  return extractSiteKit(data, "Teamsbyseason");
 }
 
 export async function getTeamRoster(
   teamId: number,
   seasonId = CURRENT_SEASON_ID
 ) {
-  return htFetch(
+  const data = await htFetch(
     `feed=modulekit&view=roster&team_id=${teamId}&season_id=${seasonId}`
   );
+  const raw = extractSiteKit(data, "Roster");
+  if (!Array.isArray(raw)) return [];
+  let roster = raw.filter((p: any) => typeof p === "object" && p !== null && !Array.isArray(p) && p.first_name);
+  if (roster.length > 0 && roster[0]?.sections) {
+    roster = roster[0].sections.flatMap((s: any) => s.data ?? []);
+  }
+  return roster;
 }
 
 // --- Players ---

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,22 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+export function playerName(p: any): string {
+  if (p?.name) return p.name;
+  const full = `${p?.first_name ?? ""} ${p?.last_name ?? ""}`.trim();
+  return full || "Unknown";
+}
+
+// GameStatus codes: 1=Not Started, 2=In Progress, 3=Intermission, 4=Final
+export function isGameLive(status: string | number): boolean {
+  const s = String(status);
+  return s === "2" || s === "3" || s.toLowerCase().includes("progress");
+}
+
+export function isGameFinal(status: string | number): boolean {
+  const s = String(status);
+  return s === "4" || s.toLowerCase().includes("final");
+}
+
 export function val(obj: any, ...keys: string[]) {
   for (const k of keys) {
     if (obj[k] !== undefined && obj[k] !== null && obj[k] !== "") return obj[k];

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -27,9 +27,7 @@ const config: Config = {
           bright: "#e8f4fc",
           dim: "#8bbdd9",
         },
-        frost: "#b8dff0",
         live: "#ef4444",
-        final: "#6b7280",
       },
       fontFamily: {
         display: ["var(--font-display)", "system-ui", "sans-serif"],
@@ -38,27 +36,16 @@ const config: Config = {
       },
       animation: {
         "pulse-live": "pulse-live 2s ease-in-out infinite",
-        "slide-in": "slide-in 0.4s ease-out",
         "fade-in": "fade-in 0.5s ease-out",
-        "score-pop": "score-pop 0.3s ease-out",
       },
       keyframes: {
         "pulse-live": {
           "0%, 100%": { opacity: "1" },
           "50%": { opacity: "0.5" },
         },
-        "slide-in": {
-          from: { transform: "translateY(8px)", opacity: "0" },
-          to: { transform: "translateY(0)", opacity: "1" },
-        },
         "fade-in": {
           from: { opacity: "0" },
           to: { opacity: "1" },
-        },
-        "score-pop": {
-          "0%": { transform: "scale(1)" },
-          "50%": { transform: "scale(1.15)" },
-          "100%": { transform: "scale(1)" },
         },
       },
     },


### PR DESCRIPTION
## Summary

**Efficiency (-63 lines net):**
- Parallelize independent API calls with `Promise.allSettled` on homepage (3→1 await), game detail (2→1), and team page (2→1)
- Schedule page uses `getTeamSchedule()` when team filter is active instead of fetching entire season and filtering client-side

**Code reuse:**
- Extract `playerName()` utility — replaces 7 inline name constructions across 5 files
- Extract `isGameLive()` / `isGameFinal()` — replaces ad-hoc string status checks
- Move `extractSiteKit()` into API functions — pages no longer need to know HockeyTech response wrapper formats

**Cleanup:**
- Remove unused CSS: custom properties, redundant `.num` rule, unused `.nav-link-active` and `.sortable`
- Remove unused Tailwind config: `frost`/`final` colors, `slide-in`/`score-pop` animations
- Remove unnecessary "what" comments from layout and pages

## Test plan
- [ ] `npm run build` compiles cleanly
- [ ] Homepage loads with parallel data (scores + standings + top scorers)
- [ ] Game detail page loads (summary + PBP fetched concurrently)
- [ ] Team page loads (roster + schedule fetched concurrently)
- [ ] Schedule page with team filter uses targeted API call
- [ ] Player names display correctly across all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)