### PR TITLE
Add live demo link and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Topper Solutions
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![CI](https://github.com/topper-solutions/pwhl-gameday/actions/workflows/ci.yml/badge.svg)](https://github.com/topper-solutions/pwhl-gameday/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/murphy-platforms/8e2b3b269fe2a325c4bf2a222685a573/raw/pwhl-gameday-coverage.json)](https://github.com/topper-solutions/pwhl-gameday/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
+**[Live Demo](https://topper.solutions/pwhl-gameday)**
 
 Unofficial stats tracker for the Professional Women's Hockey League. Live scores, standings, player stats, schedules, and game details with real-time updates during active games.
 
@@ -152,4 +155,4 @@ These keys are publicly visible in thepwhl.com's client-side JavaScript. They ar
 
 ## License
 
-Private project. Not licensed for redistribution.
+MIT — see [LICENSE](LICENSE) for details.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "pwhl-gameday",
   "version": "1.1.0",
   "private": true,
+  "license": "MIT",
+  "homepage": "https://topper.solutions/pwhl-gameday",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary
- Added live demo link and MIT license badge to README
- Created MIT LICENSE file (copyright Topper Solutions)
- Updated package.json with `homepage` and `license` fields
- Changed license section from "Private project" to MIT

## Test plan
- [ ] Verify live demo link resolves: https://topper.solutions/pwhl-gameday
- [ ] Confirm license badge renders on GitHub README
- [ ] `npm run build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)