### PR TITLE
Add Scriptable iOS widget and setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Unofficial stats tracker for the Professional Women's Hockey League. Live scores
 - **Data freshness** — staleness indicator warns when ISR-cached data may be outdated
 - **Health monitoring** — `/api/health` endpoint checks upstream API reachability
 
+## Widget
+
+A [Scriptable](https://scriptable.app) widget for your iPhone Home Screen shows live scores, results, and upcoming games at a glance — no app required.
+
+[Setup instructions](docs/scriptable-widget.md) · [Download script](widget/PWHL-Gameday-Widget.js)
+
 ## Getting Started
 
 ```bash

--- a/docs/scriptable-widget.md
+++ b/docs/scriptable-widget.md
@@ -1,0 +1,153 @@
+# PWHL Gameday iPhone Widget
+
+Add live PWHL scores to your iPhone Home Screen using the free [Scriptable](https://scriptable.app) app. The widget shows up to four games — live scores update automatically, with winner bolded for completed games.
+
+**[Download widget script](../widget/PWHL-Gameday-Widget.js)**
+
+---
+
+## Quick Reference
+
+If you're comfortable with your iPhone, here's the short version. Detailed instructions for each step follow below.
+
+1. **Install Scriptable** from the App Store (free, by Simon B. Støvring)
+2. **Open Scriptable** and tap the **+** button to create a new script
+3. **Paste** the [widget script](../widget/PWHL-Gameday-Widget.js) into the editor
+4. **Name the script** by tapping the title at the top — type **PWHL Gameday**
+5. **Run it once** by tapping the **▶ Play** button to test and grant permissions
+6. **Add the widget:** Go to your Home Screen → long-press an empty area → tap **+** → search **Scriptable** → choose **Medium** → tap **Add Widget**
+7. **Connect it:** Long-press the new widget → **Edit Widget** → tap **Script** → select **PWHL Gameday**
+
+That's it. The widget will refresh automatically every 15–30 minutes.
+
+---
+
+## What You'll Need
+
+- An iPhone running iOS 16 or later
+- The **Scriptable** app (free from the App Store)
+- The [widget script](../widget/PWHL-Gameday-Widget.js) — copy the raw file contents
+
+---
+
+## Detailed Instructions
+
+### Part 1: Install Scriptable
+
+1. Open the **App Store** on your iPhone.
+2. Tap the **Search** tab at the bottom and type **Scriptable**.
+3. Look for the app by **Simon B. Støvring** — it has a dark icon with overlapping circles.
+4. Tap **Get** to download and install it. The app is completely free with no ads or in-app purchases.
+5. Once installed, open Scriptable briefly to confirm it launches. You'll see an empty list — that's normal.
+
+---
+
+### Part 2: Add the Script to Scriptable
+
+1. Open the [widget script](../widget/PWHL-Gameday-Widget.js) on GitHub and tap the **Raw** button to view the plain text.
+2. **Select all** of the script text and tap **Copy**. Make sure you copy the entire script from the very first line to the very last line.
+3. Open the **Scriptable** app.
+4. Tap the **blue "+" button** in the top-right corner to create a new script.
+5. You'll see a blank editor screen with a blinking cursor. **Tap and hold** in the editor area, then tap **Paste**.
+6. The script text should now appear in the editor.
+
+**Alternative: Import via AirDrop or Files**
+
+If you have the `.js` file on your device:
+
+1. Tap on the file.
+2. If prompted, choose **Open in Scriptable**. The script will be imported automatically.
+3. If that option doesn't appear, save the file to **Files → iCloud Drive → Scriptable**. The app will pick it up on its own.
+
+---
+
+### Part 3: Name Your Script
+
+1. In the Scriptable editor, tap the **title area** at the very top of the screen. It will say something like "Untitled Script."
+2. Delete the placeholder name and type **PWHL Gameday**.
+3. Tap **Done** on the keyboard.
+
+---
+
+### Part 4: Test the Script
+
+Before placing the widget on your Home Screen, run the script once inside the app. This confirms everything is working and allows the script to request any permissions it needs (such as internet access).
+
+1. With your script open in the editor, tap the **blue Play button (▶)** in the bottom-right corner of the screen.
+2. The script will run and show you a **preview** of what the widget will look like.
+3. If you see scores, team names, or a "No games found" message — you're all set. Tap anywhere to dismiss the preview.
+4. If you see an error message, double-check that the entire script was pasted correctly and that no text was cut off.
+
+> **Important:** Always run a new script inside the Scriptable app at least once before adding it to your Home Screen. Some scripts need this first run to get permission to access the internet or other features.
+
+---
+
+### Part 5: Add the Widget to Your Home Screen
+
+**Enter jiggle mode**
+
+1. Go to your iPhone's **Home Screen**.
+2. **Long-press** (press and hold) on any empty area of the screen until the app icons start wiggling.
+3. Tap the **"+" button** that appears in the top-left corner of the screen.
+
+**Find Scriptable**
+
+4. A widget gallery will appear. Use the **search bar** at the top and type **Scriptable**.
+5. Tap on **Scriptable** in the search results.
+
+**Choose a widget size**
+
+6. You'll see three size options. Swipe left and right to browse them:
+   - **Small** — a compact square (shows one or two games)
+   - **Medium** — a wide rectangle (recommended, shows up to four games)
+   - **Large** — a tall rectangle (shows the most information)
+7. Tap **"Add Widget"** below the **Medium** size.
+
+**Place the widget**
+
+8. The widget will appear on your Home Screen, probably showing a generic Scriptable placeholder. You can **drag it** to your preferred location while the icons are still wiggling.
+
+---
+
+### Part 6: Connect the Widget to Your Script
+
+1. While still in jiggle mode (icons wiggling), **tap directly on the widget** you just added. A settings panel will slide up.
+   - If you've already exited jiggle mode, long-press the widget and choose **"Edit Widget"** from the menu.
+2. You'll see a configuration screen with these options:
+   - **Script** — Tap this and select **PWHL Gameday**.
+   - **When Interacting** — Leave this set to the default.
+   - **Parameter** — Leave this blank.
+3. Tap anywhere **outside** the settings panel to close it.
+4. Tap **Done** in the top-right corner to exit jiggle mode.
+
+Your widget should now load and display live data. Give it a few seconds — it needs to fetch information the first time.
+
+---
+
+## Troubleshooting
+
+**The widget says "Select Script in Widget Configurator"**
+You added the widget but didn't complete Part 6. Long-press the widget, tap "Edit Widget," and select **PWHL Gameday**.
+
+**The widget shows an error or goes blank**
+Open the Scriptable app and run the script with the Play button to check for errors. Make sure your iPhone has an internet connection. Confirm the entire script was pasted — a partially copied script is the most common cause of errors.
+
+**The widget isn't updating**
+Apple controls how frequently widgets refresh — roughly every 15 to 30 minutes. The widget may refresh less often if your phone is in Low Power Mode. To force a refresh, open the Scriptable app and run the script manually.
+
+**I want to update to a newer version of the script**
+Open Scriptable, tap on your existing script, select all the text and delete it, then paste the new version. Run it once with the Play button to confirm it works. The Home Screen widget will pick up the changes on its next refresh.
+
+---
+
+## Good to Know
+
+**Tapping the widget** opens PWHL Gameday in Safari.
+
+**You can have multiple Scriptable widgets** on your Home Screen, each running a different script. Repeat Parts 5 and 6 for each one and select a different script in the configuration step.
+
+**The widget's appearance** (colors, fonts, layout) is controlled by the script. If you'd like changes, edit the script in Scriptable or open an issue on GitHub.
+
+---
+
+*Scriptable is a free app created by Simon B. Støvring. It is not affiliated with the PWHL or PWHL Gameday. For more information, visit [scriptable.app](https://scriptable.app).*

--- a/widget/PWHL-Gameday-Widget.js
+++ b/widget/PWHL-Gameday-Widget.js
@@ -1,0 +1,256 @@
+// PWHL Gameday Widget for Scriptable
+// Shows recent PWHL scores on your iPhone Home Screen
+//
+// SETUP:
+// 1. Install Scriptable from the App Store
+// 2. Open Scriptable, tap +, paste this script
+// 3. Name it PWHL Gameday
+// 4. Long-press Home Screen, tap +, search Scriptable
+// 5. Add a Medium widget, tap it, choose PWHL Gameday
+
+var SCOUT_URL = "https://topper.solutions/pwhl-gameday";
+
+var TEAM_COLORS = {
+  "BOS": "#1a3c5e",
+  "MTL": "#6b2d6b",
+  "MIN": "#2e7d5b",
+  "TOR": "#1d428a",
+  "OTT": "#c8102e",
+  "NYS": "#00a3e0",
+  "VAN": "#00573f",
+  "SEA": "#4b9cd3"
+};
+
+var TEAM_MAP = {
+  "Boston": "BOS",
+  "Montreal": "MTL",
+  "Montr": "MTL",
+  "Minnesota": "MIN",
+  "Toronto": "TOR",
+  "Ottawa": "OTT",
+  "New York": "NYS",
+  "Vancouver": "VAN",
+  "Seattle": "SEA"
+};
+
+function abbr(name) {
+  var keys = Object.keys(TEAM_MAP);
+  for (var i = 0; i < keys.length; i++) {
+    if (name.indexOf(keys[i]) !== -1) {
+      return TEAM_MAP[keys[i]];
+    }
+  }
+  return name.substring(0, 3).toUpperCase();
+}
+
+function teamColor(code) {
+  return new Color(TEAM_COLORS[code] || "#666666");
+}
+
+async function fetchGames() {
+  var req = new Request(SCOUT_URL);
+  var html = await req.loadString();
+  var games = [];
+
+  // Split by game links
+  var chunks = html.split(/href="\/pwhl-gameday\/game\//);
+  chunks.shift(); // remove preamble
+
+  for (var c = 0; c < chunks.length && games.length < 6; c++) {
+    var chunk = chunks[c];
+    var idMatch = chunk.match(/^(\d+)/);
+    if (!idMatch) continue;
+
+    // Get team names from alt attributes
+    var alts = [];
+    var altRe = /alt="([^"]+)"/g;
+    var am;
+    while ((am = altRe.exec(chunk)) !== null) {
+      alts.push(am[1]);
+    }
+    if (alts.length < 2) continue;
+
+    var awayCode = abbr(alts[0]);
+    var homeCode = abbr(alts[1]);
+
+    // Determine status
+    var status = "";
+    var isLive = false;
+    var isScheduled = false;
+
+    if (chunk.indexOf("Final") !== -1) {
+      status = "F";
+    } else if (chunk.match(/\d+:\d+\s*(AM|PM)/i)) {
+      var tm = chunk.match(/(\d+:\d+\s*(AM|PM))/i);
+      status = tm ? tm[1] : "TBD";
+      isScheduled = true;
+    } else if (chunk.match(/(1st|2nd|3rd|OT)/)) {
+      var pm2 = chunk.match(/(1st|2nd|3rd|OT)/);
+      status = pm2[1];
+      isLive = true;
+    }
+
+    // Extract scores - digits that appear standalone
+    var awayScore = "-";
+    var homeScore = "-";
+    if (!isScheduled) {
+      // Look for standalone single or double digit numbers
+      var scoreNums = [];
+      var snRe = />\s*(\d{1,2})\s*</g;
+      var sn;
+      while ((sn = snRe.exec(chunk)) !== null) {
+        scoreNums.push(sn[1]);
+      }
+      if (scoreNums.length >= 2) {
+        awayScore = scoreNums[0];
+        homeScore = scoreNums[1];
+      }
+    }
+
+    games.push({
+      away: awayCode,
+      home: homeCode,
+      awayScore: awayScore,
+      homeScore: homeScore,
+      status: status,
+      isLive: isLive,
+      isScheduled: isScheduled
+    });
+  }
+
+  return games;
+}
+
+function drawGame(col, game) {
+  var box = col.addStack();
+  box.layoutVertically();
+  box.setPadding(5, 6, 5, 6);
+  box.cornerRadius = 6;
+  box.backgroundColor = new Color("#252540");
+
+  // Status line
+  var stLine = box.addStack();
+  stLine.layoutHorizontally();
+  var stText = stLine.addText(game.isLive ? "LIVE" : game.status);
+  stText.font = Font.boldSystemFont(8);
+  stText.textColor = game.isLive ? new Color("#ef4444") : new Color("#888888");
+  stLine.addSpacer();
+
+  box.addSpacer(3);
+
+  // Away
+  var aRow = box.addStack();
+  aRow.layoutHorizontally();
+  aRow.centerAlignContent();
+  var aDot = aRow.addText("\u25CF ");
+  aDot.font = Font.systemFont(7);
+  aDot.textColor = teamColor(game.away);
+  var aName = aRow.addText(game.away);
+  aName.font = Font.mediumSystemFont(12);
+  aName.textColor = Color.white();
+  aRow.addSpacer();
+  if (!game.isScheduled) {
+    var aWin = !game.isLive && parseInt(game.awayScore) > parseInt(game.homeScore);
+    var aScore = aRow.addText(game.awayScore);
+    aScore.font = aWin ? Font.boldSystemFont(13) : Font.systemFont(12);
+    aScore.textColor = aWin ? Color.white() : new Color("#aaaaaa");
+  }
+
+  box.addSpacer(1);
+
+  // Home
+  var hRow = box.addStack();
+  hRow.layoutHorizontally();
+  hRow.centerAlignContent();
+  var hDot = hRow.addText("\u25CF ");
+  hDot.font = Font.systemFont(7);
+  hDot.textColor = teamColor(game.home);
+  var hName = hRow.addText(game.home);
+  hName.font = Font.mediumSystemFont(12);
+  hName.textColor = Color.white();
+  hRow.addSpacer();
+  if (!game.isScheduled) {
+    var hWin = !game.isLive && parseInt(game.homeScore) > parseInt(game.awayScore);
+    var hScore = hRow.addText(game.homeScore);
+    hScore.font = hWin ? Font.boldSystemFont(13) : Font.systemFont(12);
+    hScore.textColor = hWin ? Color.white() : new Color("#aaaaaa");
+  }
+}
+
+async function createWidget() {
+  var w = new ListWidget();
+  w.backgroundColor = new Color("#1a1a2e");
+  w.setPadding(10, 10, 10, 10);
+  w.url = SCOUT_URL;
+
+  // Header
+  var hdr = w.addStack();
+  hdr.layoutHorizontally();
+  hdr.centerAlignContent();
+  var t = hdr.addText("PWHL GAMEDAY");
+  t.font = Font.boldSystemFont(11);
+  t.textColor = new Color("#e0e0e0");
+  hdr.addSpacer();
+  var now = new Date();
+  var ts = now.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+  var upd = hdr.addText(ts);
+  upd.font = Font.systemFont(8);
+  upd.textColor = new Color("#666666");
+
+  w.addSpacer(6);
+
+  try {
+    var games = await fetchGames();
+
+    // Sort: live first, then final, then scheduled
+    var live = [];
+    var final2 = [];
+    var sched = [];
+    for (var i = 0; i < games.length; i++) {
+      if (games[i].isLive) live.push(games[i]);
+      else if (games[i].isScheduled) sched.push(games[i]);
+      else final2.push(games[i]);
+    }
+    var sorted = live.concat(final2).concat(sched);
+    var show = sorted.slice(0, 4);
+
+    if (show.length === 0) {
+      var ng = w.addText("No games found");
+      ng.font = Font.systemFont(12);
+      ng.textColor = new Color("#999999");
+    } else {
+      var row1 = w.addStack();
+      row1.layoutHorizontally();
+      row1.spacing = 6;
+
+      drawGame(row1, show[0]);
+      if (show.length > 1) drawGame(row1, show[1]);
+
+      if (show.length > 2) {
+        w.addSpacer(4);
+        var row2 = w.addStack();
+        row2.layoutHorizontally();
+        row2.spacing = 6;
+        drawGame(row2, show[2]);
+        if (show.length > 3) drawGame(row2, show[3]);
+      }
+    }
+  } catch (e) {
+    var err = w.addText("Could not load scores");
+    err.font = Font.systemFont(11);
+    err.textColor = new Color("#ef4444");
+  }
+
+  w.addSpacer();
+  return w;
+}
+
+var widget = await createWidget();
+
+if (config.runsInWidget) {
+  Script.setWidget(widget);
+} else {
+  await widget.presentMedium();
+}
+
+Script.complete();


### PR DESCRIPTION
## Summary
- Adds `widget/PWHL-Gameday-Widget.js` — Scriptable script for iPhone Home Screen PWHL scores (up to 4 games, live/final/scheduled, sorted live-first)
- Adds `docs/scriptable-widget.md` — step-by-step setup guide adapted for PWHL Gameday branding
- Updates README with a `## Widget` section linking to both files
- Fixes stale `pwhl-scout` URL references in the widget script → `pwhl-gameday`

## Test plan
- [ ] Raw widget script link resolves from README
- [ ] Setup guide renders correctly on GitHub
- [ ] Widget script parses games correctly when run in Scriptable against `https://topper.solutions/pwhl-gameday`

🤖 Generated with [Claude Code](https://claude.com/claude-code)