### PR TITLE
Increase test coverage to 100%

### DIFF
--- a/src/app/api/health/route.test.ts
+++ b/src/app/api/health/route.test.ts
@@ -118,6 +118,26 @@ describe("/api/health", () => {
     });
   });
 
+  it("reports Firebase as down when fetch throws a network error", async () => {
+    mockFetch(
+      vi.fn()
+        .mockResolvedValueOnce(okResponse())
+        .mockRejectedValueOnce(new Error("Failed to fetch")),
+    );
+    const GET = await getHandler();
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("degraded");
+    expect(body.upstreams[0]).toMatchObject({ name: "hockeytech", status: "ok" });
+    expect(body.upstreams[1]).toMatchObject({
+      name: "firebase",
+      status: "down",
+      error: "Failed to fetch",
+    });
+  });
+
   it("includes positive latency values for successful checks", async () => {
     mockFetch(vi.fn().mockResolvedValue(okResponse()));
     const GET = await getHandler();

--- a/src/app/game/[id]/page.test.tsx
+++ b/src/app/game/[id]/page.test.tsx
@@ -22,15 +22,29 @@ vi.mock("@/lib/api", () => ({
 }));
 
 vi.mock("@/lib/teams", () => ({
-  getTeamMeta: vi.fn(() => ({
-    id: 1,
-    abbr: "BOS",
-    name: "Fleet",
-    city: "Boston",
-    color: "#154734",
-    colorAlt: "#C5B783",
-    logo: "",
-  })),
+  getTeamMeta: vi.fn((id: unknown) => {
+    const numId = typeof id === "string" ? parseInt(id) : Number(id);
+    if (numId === 2) {
+      return {
+        id: 2,
+        abbr: "MIN",
+        name: "Frost",
+        city: "Minnesota",
+        color: "#2E8B57",
+        colorAlt: "#B0C4DE",
+        logo: "",
+      };
+    }
+    return {
+      id: 1,
+      abbr: "BOS",
+      name: "Fleet",
+      city: "Boston",
+      color: "#154734",
+      colorAlt: "#C5B783",
+      logo: "",
+    };
+  }),
 }));
 
 vi.mock("@/components/team-logo", () => ({
@@ -43,8 +57,23 @@ vi.mock("@/components/live-scoreboard", () => ({
   LiveScoreboard: () => <div data-testid="live-scoreboard" />,
 }));
 
-import GamePage from "./page";
+import GamePage, { generateMetadata } from "./page";
 import { getGameSummary, getPlayByPlay } from "@/lib/api";
+
+function baseSummary(overrides: Record<string, unknown> = {}) {
+  return {
+    home: { team_id: "1", id: "1", name: "Boston Fleet" },
+    visitor: { team_id: "2", id: "2", name: "Minnesota Frost" },
+    totalGoals: { home: 3, visitor: 1 },
+    goals: [],
+    penalties: [],
+    mvps: [],
+    status_value: "Final",
+    game_date: "2025-12-01",
+    venue: "TD Garden",
+    ...overrides,
+  };
+}
 
 describe("GamePage", () => {
   beforeEach(() => {
@@ -72,17 +101,7 @@ describe("GamePage", () => {
   });
 
   it("renders game page without PBP when PBP rejects", async () => {
-    (getGameSummary as Mock).mockResolvedValue({
-      home: { team_id: "1", id: "1", name: "Boston Fleet" },
-      visitor: { team_id: "2", id: "2", name: "Minnesota Frost" },
-      totalGoals: { home: 3, visitor: 1 },
-      goals: [],
-      penalties: [],
-      mvps: [],
-      status_value: "Final",
-      game_date: "2025-12-01",
-      venue: "TD Garden",
-    });
+    (getGameSummary as Mock).mockResolvedValue(baseSummary());
     (getPlayByPlay as Mock).mockRejectedValue(new Error("PBP down"));
 
     const jsx = await GamePage({ params: Promise.resolve({ id: "100" }) });
@@ -93,38 +112,32 @@ describe("GamePage", () => {
   });
 
   it("renders full game page when both succeed", async () => {
-    (getGameSummary as Mock).mockResolvedValue({
-      home: { team_id: "1", id: "1", name: "Boston Fleet" },
-      visitor: { team_id: "2", id: "2", name: "Minnesota Frost" },
-      totalGoals: { home: 3, visitor: 1 },
-      goals: [
-        {
-          event: "goal",
-          time: "5:30",
-          team_id: "1",
-          home: "1",
-          period_id: "1",
-          power_play: "0",
-          short_handed: "0",
-          empty_net: "0",
-          goal_scorer: {
-            player_id: "10",
-            first_name: "Jane",
-            last_name: "Doe",
-            jersey_number: "9",
+    (getGameSummary as Mock).mockResolvedValue(
+      baseSummary({
+        goals: [
+          {
+            event: "goal",
+            time: "5:30",
             team_id: "1",
-            team_code: "BOS",
+            home: "1",
+            period_id: "1",
+            power_play: "0",
+            short_handed: "0",
+            empty_net: "0",
+            goal_scorer: {
+              player_id: "10",
+              first_name: "Jane",
+              last_name: "Doe",
+              jersey_number: "9",
+              team_id: "1",
+              team_code: "BOS",
+            },
+            assist1_player: { player_id: null, first_name: null, last_name: null },
+            assist2_player: { player_id: null, first_name: null, last_name: null },
           },
-          assist1_player: { player_id: null, first_name: null, last_name: null },
-          assist2_player: { player_id: null, first_name: null, last_name: null },
-        },
-      ],
-      penalties: [],
-      mvps: [],
-      status_value: "Final",
-      game_date: "2025-12-01",
-      venue: "TD Garden",
-    });
+        ],
+      })
+    );
     (getPlayByPlay as Mock).mockResolvedValue([
       { event: "goal", time: "5:30", time_formatted: "5:30" },
     ]);
@@ -135,5 +148,171 @@ describe("GamePage", () => {
     expect(screen.getByTestId("live-scoreboard")).toBeInTheDocument();
     expect(screen.getByText("Scoring Summary")).toBeInTheDocument();
     expect(screen.getByText("Play-by-Play")).toBeInTheDocument();
+  });
+
+  it("renders GoalRow with PP, SH, and EN badges", async () => {
+    (getGameSummary as Mock).mockResolvedValue(
+      baseSummary({
+        goals: [
+          {
+            event: "goal",
+            time: "10:00",
+            team_id: "1",
+            home: "1",
+            period_id: "1",
+            power_play: "1",
+            short_handed: "0",
+            empty_net: "0",
+            goal_scorer: { player_id: "10", first_name: "Jane", last_name: "Doe" },
+            assist1_player: { player_id: "11", first_name: "Alex", last_name: "Smith" },
+            assist2_player: { player_id: "12", first_name: "Sam", last_name: "Lee" },
+          },
+          {
+            event: "goal",
+            time: "15:00",
+            team_id: "2",
+            home: "0",
+            period_id: "2",
+            power_play: "0",
+            short_handed: "1",
+            empty_net: "0",
+            goal_scorer: { player_id: "20", first_name: "Kim", last_name: "Park" },
+            assist1_player: { player_id: null, first_name: null, last_name: null },
+            assist2_player: { player_id: null, first_name: null, last_name: null },
+          },
+          {
+            event: "goal",
+            time: "19:00",
+            team_id: "1",
+            home: "1",
+            period_id: "3",
+            power_play: "0",
+            short_handed: "0",
+            empty_net: "1",
+            goal_scorer: { player_id: "30", first_name: "Erin", last_name: "Cole" },
+            assist1_player: { player_id: null, first_name: null, last_name: null },
+            assist2_player: { player_id: null, first_name: null, last_name: null },
+          },
+        ],
+      })
+    );
+    (getPlayByPlay as Mock).mockResolvedValue([]);
+
+    const jsx = await GamePage({ params: Promise.resolve({ id: "100" }) });
+    render(jsx);
+
+    expect(screen.getByText("PP")).toBeInTheDocument();
+    expect(screen.getByText("SH")).toBeInTheDocument();
+    expect(screen.getByText("EN")).toBeInTheDocument();
+    expect(screen.getByText(/Assists:/)).toBeInTheDocument();
+  });
+
+  it("renders Three Stars section when mvps are present", async () => {
+    (getGameSummary as Mock).mockResolvedValue(
+      baseSummary({
+        mvps: [
+          { player_id: "10", first_name: "Jane", last_name: "Doe", jersey_number: "9", home: "1" },
+          { player_id: "20", first_name: "Kim", last_name: "Park", jersey_number: "7", home: "0" },
+          { player_id: "30", first_name: "Erin", last_name: "Cole", jersey_number: "5", home: "1" },
+        ],
+      })
+    );
+    (getPlayByPlay as Mock).mockResolvedValue([]);
+
+    const jsx = await GamePage({ params: Promise.resolve({ id: "100" }) });
+    render(jsx);
+
+    expect(screen.getByText("Three Stars")).toBeInTheDocument();
+    expect(screen.getByText("1st Star")).toBeInTheDocument();
+    expect(screen.getByText("2nd Star")).toBeInTheDocument();
+    expect(screen.getByText("3rd Star")).toBeInTheDocument();
+  });
+
+  it("renders Shots on Goal section when shot data is present", async () => {
+    (getGameSummary as Mock).mockResolvedValue(
+      baseSummary({
+        shotsByPeriod: {
+          visitor: { "1": 10, "2": 8, "3": 12 },
+          home: { "1": 12, "2": 9, "3": 11 },
+        },
+        totalShots: { visitor: 30, home: 32 },
+      })
+    );
+    (getPlayByPlay as Mock).mockResolvedValue([]);
+
+    const jsx = await GamePage({ params: Promise.resolve({ id: "100" }) });
+    render(jsx);
+
+    expect(screen.getByText("Shots on Goal")).toBeInTheDocument();
+  });
+
+  it("renders Penalties section when penalties are present", async () => {
+    (getGameSummary as Mock).mockResolvedValue(
+      baseSummary({
+        penalties: [
+          {
+            team_id: "1",
+            player_penalized_info: { player_id: "10", first_name: "Jane", last_name: "Doe" },
+            minutes_formatted: "2:00",
+            lang_penalty_description: "Tripping",
+            period: "1st",
+            time_off_formatted: "10:00",
+          },
+        ],
+      })
+    );
+    (getPlayByPlay as Mock).mockResolvedValue([]);
+
+    const jsx = await GamePage({ params: Promise.resolve({ id: "100" }) });
+    render(jsx);
+
+    expect(screen.getByText("Penalties")).toBeInTheDocument();
+    expect(screen.getByText(/Tripping/)).toBeInTheDocument();
+  });
+
+  it("renders Linescore with OT period when OT goals exist", async () => {
+    (getGameSummary as Mock).mockResolvedValue(
+      baseSummary({
+        totalGoals: { home: 2, visitor: 1 },
+        goals: [
+          {
+            event: "goal", time: "5:00", team_id: "1", home: "1", period_id: "1",
+            power_play: "0", short_handed: "0", empty_net: "0",
+            goal_scorer: { player_id: "10", first_name: "Jane", last_name: "Doe" },
+            assist1_player: { player_id: null }, assist2_player: { player_id: null },
+          },
+          {
+            event: "goal", time: "10:00", team_id: "2", home: "0", period_id: "2",
+            power_play: "0", short_handed: "0", empty_net: "0",
+            goal_scorer: { player_id: "20", first_name: "Kim", last_name: "Park" },
+            assist1_player: { player_id: null }, assist2_player: { player_id: null },
+          },
+          {
+            event: "goal", time: "3:00", team_id: "1", home: "1", period_id: "4",
+            power_play: "0", short_handed: "0", empty_net: "0",
+            goal_scorer: { player_id: "10", first_name: "Jane", last_name: "Doe" },
+            assist1_player: { player_id: null }, assist2_player: { player_id: null },
+          },
+        ],
+      })
+    );
+    (getPlayByPlay as Mock).mockResolvedValue([]);
+
+    const jsx = await GamePage({ params: Promise.resolve({ id: "100" }) });
+    render(jsx);
+
+    expect(screen.getByText("OT")).toBeInTheDocument();
+    expect(screen.getByText("Overtime")).toBeInTheDocument();
+  });
+});
+
+describe("generateMetadata", () => {
+  it("returns title and description with game ID", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ id: "42" }),
+    });
+
+    expect(metadata.title).toBe("Game #42 | PWHL Gameday");
+    expect(metadata.description).toContain("42");
   });
 });

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -140,6 +140,55 @@ describe("HomePage", () => {
     expect(screen.getByText("No games scheduled today")).toBeInTheDocument();
   });
 
+  it("renders Live status for a live game", async () => {
+    (getScorebar as Mock).mockResolvedValue([
+      {
+        ID: "101",
+        HomeID: "1",
+        VisitorID: "2",
+        HomeGoals: "2",
+        VisitorGoals: "1",
+        GameStatusStringLong: "In Progress",
+        GameStatus: "2",
+        GameDate: "2025-12-01",
+        HomeLongName: "Boston Fleet",
+        VisitorLongName: "Minnesota Frost",
+      },
+    ]);
+    (getStandings as Mock).mockResolvedValue([]);
+    (getTopScorers as Mock).mockResolvedValue([]);
+
+    const jsx = await HomePage();
+    render(jsx);
+
+    expect(screen.getByText("Live")).toBeInTheDocument();
+  });
+
+  it("renders Scheduled status for an upcoming game", async () => {
+    (getScorebar as Mock).mockResolvedValue([
+      {
+        ID: "102",
+        HomeID: "1",
+        VisitorID: "2",
+        HomeGoals: "",
+        VisitorGoals: "",
+        GameStatusStringLong: "",
+        GameStatus: "1",
+        GameDate: "2025-12-01",
+        ScheduledFormattedTime: "7:00 PM",
+        HomeLongName: "Boston Fleet",
+        VisitorLongName: "Minnesota Frost",
+      },
+    ]);
+    (getStandings as Mock).mockResolvedValue([]);
+    (getTopScorers as Mock).mockResolvedValue([]);
+
+    const jsx = await HomePage();
+    render(jsx);
+
+    expect(screen.getByText("Scheduled")).toBeInTheDocument();
+  });
+
   it("renders error banner and no standings/scorers when all reject", async () => {
     (getScorebar as Mock).mockRejectedValue(new Error("fail"));
     (getStandings as Mock).mockRejectedValue(new Error("fail"));

--- a/src/app/schedule/page.test.tsx
+++ b/src/app/schedule/page.test.tsx
@@ -74,6 +74,16 @@ describe("SchedulePage", () => {
         visiting_goal_count: "1",
         game_status: "Final",
       },
+      {
+        game_id: "201",
+        date_played: "2025-11-28",
+        date_with_day: "Fri Nov 28",
+        home_team: "2",
+        visiting_team: "1",
+        home_goal_count: "2",
+        visiting_goal_count: "4",
+        game_status: "Final",
+      },
     ]);
 
     const jsx = await SchedulePage({ searchParams: Promise.resolve({}) });

--- a/src/app/stats/page.test.tsx
+++ b/src/app/stats/page.test.tsx
@@ -79,6 +79,45 @@ describe("StatsPage", () => {
     expect(screen.getByText("Jane Doe")).toBeInTheDocument();
   });
 
+  it("filters players by team when team param is set", async () => {
+    (getSkaterStats as Mock).mockResolvedValue([
+      {
+        player_id: "10",
+        first_name: "Jane",
+        last_name: "Doe",
+        name: "Jane Doe",
+        position: "C",
+        team_id: "1",
+        team_code: "BOS",
+        games_played: "20",
+        goals: "15",
+        assists: "20",
+        points: "35",
+      },
+      {
+        player_id: "20",
+        first_name: "Kim",
+        last_name: "Park",
+        name: "Kim Park",
+        position: "D",
+        team_id: "2",
+        team_code: "MIN",
+        games_played: "18",
+        goals: "5",
+        assists: "10",
+        points: "15",
+      },
+    ]);
+
+    const jsx = await StatsPage({
+      searchParams: Promise.resolve({ team: "1" }),
+    });
+    render(jsx);
+
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+    expect(screen.queryByText("Kim Park")).not.toBeInTheDocument();
+  });
+
   it("renders goalie stats when view=goalies", async () => {
     (getGoalieStats as Mock).mockResolvedValue([
       {

--- a/src/app/team/[id]/page.test.tsx
+++ b/src/app/team/[id]/page.test.tsx
@@ -43,7 +43,7 @@ vi.mock("@/components/team-logo", () => ({
   ),
 }));
 
-import TeamPage from "./page";
+import TeamPage, { generateMetadata } from "./page";
 import { getTeamRoster, getTeamSchedule } from "@/lib/api";
 
 describe("TeamPage", () => {
@@ -143,5 +143,16 @@ describe("TeamPage", () => {
     expect(screen.getByText("Jane Doe")).toBeInTheDocument();
     expect(screen.getByText("Alex Smith")).toBeInTheDocument();
     expect(screen.getByText("Schedule")).toBeInTheDocument();
+  });
+});
+
+describe("generateMetadata", () => {
+  it("returns title and description with team name", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ id: "1" }),
+    });
+
+    expect(metadata.title).toBe("Boston Fleet | PWHL Gameday");
+    expect(metadata.description).toContain("Boston Fleet");
   });
 });

--- a/src/components/data-freshness.test.tsx
+++ b/src/components/data-freshness.test.tsx
@@ -45,4 +45,16 @@ describe("DataFreshness", () => {
     expect(screen.getByText(/may be outdated/)).toBeInTheDocument();
     expect(screen.getByText(/2 min ago/)).toBeInTheDocument();
   });
+
+  it("shows hours-ago format when age exceeds 60 minutes", () => {
+    const now = Date.now();
+    vi.setSystemTime(now + 3_700_000); // 3700s = ~61 minutes → "1h ago"
+    render(<DataFreshness renderedAt={now} revalidateSeconds={60} />);
+
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+
+    expect(screen.getByText(/1h ago/)).toBeInTheDocument();
+  });
 });

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -87,6 +87,11 @@ describe("val", () => {
     expect(val({ a: "", b: "found" }, "a", "b")).toBe("found");
   });
 
+  it("returns em-dash when obj is null or undefined", () => {
+    expect(val(null, "a")).toBe("—");
+    expect(val(undefined, "a")).toBe("—");
+  });
+
   it("returns em-dash when no keys match", () => {
     expect(val({}, "a", "b")).toBe("—");
     expect(val({ x: null }, "a")).toBe("—");


### PR DESCRIPTION
## Summary
- Adds 13 new tests across 8 test files (183 → 196 total)
- Achieves **100% coverage** on statements, functions, and lines (up from 92.58%)
- Covers previously untested: game page features (Three Stars, Shots on Goal, Penalties, GoalRow badges, OT linescore, generateMetadata), homepage GameStatus branches, Firebase network errors, schedule month cache, stats team filter, team page metadata, data-freshness hours format, and `val()` null guard

## Test plan
- [x] `npx vitest run` — 196 tests pass
- [x] `npx vitest run --coverage` — 100% statements, functions, lines
- [x] `npm run build` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)